### PR TITLE
Fix launcher failing when shebang has unquoted interpreter followed by args

### DIFF
--- a/PC/launcher.c
+++ b/PC/launcher.c
@@ -406,6 +406,8 @@ find_executable_and_args(wchar_t * line, wchar_t ** argp)
     }
     /* p points just past the executable. It must either be a NUL or whitespace. */
     assert(*p != L'"', "Terminating quote without starting quote for executable in shebang line.");
+    /* if p is whitespace, make it NULL to truncate 'line', and advance */
+    if (*p && iswspace(*p)) *p++ = L'\0';
     /* Now we can skip the whitespace, having checked that it's there. */
     while(*p && iswspace(*p))
         ++p;

--- a/tests/scripts/script6.py
+++ b/tests/scripts/script6.py
@@ -1,0 +1,9 @@
+#!python
+import sys
+import os
+input = repr(sys.stdin.read())
+print(os.path.basename(sys.argv[0]))
+print(sys.argv[1:])
+print(input)
+if __debug__:
+    print('non-optimized')

--- a/tests/scripts/script7.pyw
+++ b/tests/scripts/script7.pyw
@@ -1,0 +1,4 @@
+#!pythonw
+import sys
+with open(sys.argv[1], 'wb') as f:
+    f.write(sys.argv[2].encode('ascii'))

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import textwrap
 
 from compat import unittest
 
@@ -149,6 +150,53 @@ class ScriptTestCase(unittest.TestCase):
             self.assertTrue(data.startswith(tlauncher))
 
     @unittest.skipIf(os.name != 'nt', 'Test is Windows-specific')
+    def test_launcher_run(self):
+        self.maker.add_launchers = True
+        files = self.maker.make('script6.py')
+        self.assertEqual(len(files), 1)
+        p = subprocess.Popen([files[0], 'Test Argument'],
+                             stdout=subprocess.PIPE, stdin=subprocess.PIPE,
+                             stderr=subprocess.STDOUT)
+        stdout, stderr = p.communicate('input'.encode('ascii'))
+        actual = stdout.decode('ascii').replace('\r\n', '\n')
+        expected = textwrap.dedent("""
+            script6.exe
+            ['Test Argument']
+            'input'
+            non-optimized
+            """).lstrip()
+        self.assertEqual(actual, expected)
+
+    @unittest.skipIf(os.name != 'nt', 'Test is Windows-specific')
+    def test_launcher_run_with_interpreter_args(self):
+        srcdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, srcdir)
+        dstdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, dstdir)
+        maker = ScriptMaker(srcdir, dstdir, add_launchers=True)
+
+        # add '-O' option to shebang to run in optimized mode
+        with open(os.path.join(HERE, 'scripts', 'script6.py'), 'r') as src, \
+                open(os.path.join(srcdir, 'script6-optimized.py'), 'w') as dst:
+            shebang = src.readline().rstrip()
+            dst.write(shebang + " -O\n")
+            dst.write(src.read())
+
+        files = maker.make('script6-optimized.py')
+        self.assertEqual(len(files), 1)
+        p = subprocess.Popen([files[0], 'Test Argument'],
+                             stdout=subprocess.PIPE, stdin=subprocess.PIPE,
+                             stderr=subprocess.STDOUT)
+        stdout, stderr = p.communicate('input'.encode('ascii'))
+        actual = stdout.decode('ascii').replace('\r\n', '\n')
+        expected = textwrap.dedent("""
+            script6-optimized.exe
+            ['Test Argument']
+            'input'
+            """).lstrip()  # 'non-optimized' is not printed this time
+        self.assertEqual(actual, expected)
+
+    @unittest.skipIf(os.name != 'nt', 'Test is Windows-specific')
     def test_windows(self):  # pragma: no cover
         wlauncher = self.maker._get_launcher('w')
         tlauncher = self.maker._get_launcher('t')
@@ -185,6 +233,23 @@ class ScriptTestCase(unittest.TestCase):
                 data = f.read()
             self.assertTrue(data.startswith(tlauncher))
             self.assertIn(executable, data)
+
+    @unittest.skipIf(os.name != 'nt', 'Test is Windows-specific')
+    def test_windows_run(self):
+        self.maker.add_launchers = True
+        files = self.maker.make('script7.pyw')
+        self.assertEqual(len(files), 1)
+
+        test_output = os.path.join(self.maker.target_dir, 'test_output.txt')
+        p = subprocess.Popen([files[0], test_output, 'Test Argument'],
+                             stdout=subprocess.PIPE, stdin=subprocess.PIPE,
+                             stderr=subprocess.STDOUT)
+        stdout, stderr = p.communicate()
+        self.assertFalse(stdout)
+        self.assertFalse(stderr)
+        with open(test_output, 'rb') as f:
+            actual = f.read().decode('ascii')
+        self.assertEqual(actual, 'Test Argument')
 
     def test_dry_run(self):
         self.maker.dry_run = True

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -176,11 +176,11 @@ class ScriptTestCase(unittest.TestCase):
         maker = ScriptMaker(srcdir, dstdir, add_launchers=True)
 
         # add '-O' option to shebang to run in optimized mode
-        with open(os.path.join(HERE, 'scripts', 'script6.py'), 'r') as src, \
-                open(os.path.join(srcdir, 'script6-optimized.py'), 'w') as dst:
-            shebang = src.readline().rstrip()
-            dst.write(shebang + " -O\n")
-            dst.write(src.read())
+        with open(os.path.join(HERE, 'scripts', 'script6.py'), 'r') as src:
+            with open(os.path.join(srcdir, 'script6-optimized.py'), 'w') as dst:
+                shebang = src.readline().rstrip()
+                dst.write(shebang + " -O\n")
+                dst.write(src.read())
 
         files = maker.make('script6-optimized.py')
         self.assertEqual(len(files), 1)


### PR DESCRIPTION
Hello!

First of all, excuse me if I send this patch to the Github mirror, instead of the [upstream mercurial repo](https://bitbucket.org/pypa/distlib) on Bitbucket. I simply don't have the time to learn another version control system... 😁  

I'm new to the Python packaging world. I discovered about distlib only recently while trying to fix an issue with setuptools' Windows .exe launchers, which don't support unicode strings as sys.argv:  
https://github.com/pypa/setuptools/pull/595

@jaraco suggested to integrate the distlib's launchers in setuptools, as the latter support unicode sys.argv and are self-contained.

However, I encountered an issue while running setuptools tests with the launchers from distlib.
The problem occurs when a script's shebang has the interpreter path without quotes, *and* it also contains interpreter arguments. E.g.:

    #!C:\Python35\python.exe -i

In this case, the distlib launchers simply fail with this error:

> Fatal error in launcher: Unable to create process using '"'

The reason was that the `find_executable_and_args` function in `launcher.c` appends the argument to the executable line, so it ends up being included twice in the final command line, i.e. once in the quoted executable string, and again on its own:

    "C:\Python35\python.exe -i" -i

(btw, the error message does not show the full cmdline string, but only the first quote character; this is probably because the `assert` function that formats the error message uses `fprintf` instead of the wide `fwprintf` version, while the `cmdline` is a `wchar_t*` -- I haven't addressed this here).

I fixed the error in `launcher.c`, and added tests to run the launchers with basic scripts (borrowed from setuptools tests).

In particular, the `test_launcher_run_with_interpreter_args` fails with the current distlib launcher, but should pass using the patched one.

Note that I have not commited the re-compiled launcher binaries, as I guess you would want to compile them yourself.

Please let me know what you think,
Thanks.